### PR TITLE
Make compatible with CommonJS and Browserify

### DIFF
--- a/build/Tone.js
+++ b/build/Tone.js
@@ -14336,6 +14336,8 @@
 		define( "Tone", [], function() {
 			return Tone;
 		});
+	} else if (typeof module === "object") {
+		module.exports = Tone;
 	} else {
 		root.Tone = Tone;
 	}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tone",
   "version": "0.4.1",
   "description": "A Web Audio framework for making interactive music in the browser.",
-  "main": "Tone.js",
+  "main": "build/Tone.js",
   "files": [
     "./README.md",
     "build/Tone.min.js",


### PR DESCRIPTION
Ran into some trouble when trying to use this library in a Browserify build, so here's a patch. Hope you accept the changes. Cheers!

- export the main Tone object on ```module```, if it exists
- fix incorrect ```main``` path in ```package.json```