### PR TITLE
prevent SyntaxError(s) in Firefox

### DIFF
--- a/Tone/signal/Signal.js
+++ b/Tone/signal/Signal.js
@@ -170,6 +170,11 @@ define(["Tone/core/Tone", "Tone/signal/WaveShaper"], function(Tone){
 		value = this._fromUnits(value);
 		//can't go below a certain value
 		value = Math.max(0.00001, value);
+		// exponentialRampToValueAt cannot ever ramp from 0, apparently.
+		// More info: https://bugzilla.mozilla.org/show_bug.cgi?id=1125600#c2
+		if (this._value.value === 0) {
+			this._value.setValueAtTime(0.00001, this.now());
+		}
 		this._value.exponentialRampToValueAtTime(value, this.toSeconds(endTime));
 		return this;
 	};
@@ -222,6 +227,10 @@ define(["Tone/core/Tone", "Tone/signal/WaveShaper"], function(Tone){
 	 */
 	Tone.Signal.prototype.setTargetAtTime = function(value, startTime, timeConstant){
 		value = this._fromUnits(value);
+		// The value will never be able to approach without timeConstant > 0.
+		// http://www.w3.org/TR/webaudio/#dfn-setTargetAtTime, where the equation
+		// is described. 0 results in a division by 0.
+		timeConstant = Math.max(0.00001, timeConstant);
 		this._value.setTargetAtTime(value, this.toSeconds(startTime), timeConstant);
 		return this;
 	};

--- a/test/tests/Core.js
+++ b/test/tests/Core.js
@@ -147,7 +147,7 @@ function(chai, Tone, Master, Bus, Note, Test, Buffer, Oscillator){
 			osc.dispose();
 		});		
 
-		it("ramps to a value given an object a ramp time", function(done){
+		it("ramps to a value given an object and ramp time", function(done){
 			var osc;
 			var setValue = 30;
 			Test.offlineTest(0.6, function(dest){


### PR DESCRIPTION
Firefox was throwing SyntaxErrors with the message "an invalid or illegal string was specified", this makes most of the examples work in Firefox! script processing is still slow, but they at least have the potential to work now. Also, more tests pass in Firefox (decreased failures by 6 or so).